### PR TITLE
Ability to configure Docker daemon options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Docker Compose installation options.
 
 A list of system users to be added to the `docker` group (so they can use Docker on the server).
 
+    docker_daemon_options:
+      storage-driver: "devicemapper"
+      log-opts:
+        max-size: "100m"
+
+Custom `dockerd` options can be configured through this dictionary representing the json file `/etc/docker/daemon.json`.
+
 ## Use with Ansible (and `docker` Python library)
 
 Many users of this role wish to also use Ansible to then _build_ Docker images and manage Docker containers on the server where Docker is installed. In this case, you can easily add in the `docker` Python library using the `geerlingguy.pip` role:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,6 @@ docker_yum_repo_enable_test: 0
 
 # A list of users who will be added to the docker group.
 docker_users: []
+
+# Docker daemon options
+docker_daemon_options: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
     path: /etc/docker
     state: directory
 
-- name: Configure docker daemon options.
+- name: Configure Docker daemon options.
   copy:
     content: "{{ docker_daemon_options | to_nice_json }}"
     dest: /etc/docker/daemon.json

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,18 @@
     state: "{{ docker_service_state }}"
     enabled: "{{ docker_service_enabled }}"
 
+- name: Ensure /etc/docker/ directory exists.
+  file:
+    path: /etc/docker
+    state: directory
+
+- name: Configure docker daemon options.
+  copy:
+    content: "{{ docker_daemon_options | to_nice_json }}"
+    dest: /etc/docker/daemon.json
+    mode: 0644
+  notify: restart docker
+
 - name: Ensure handlers are notified now to avoid firewall conflicts.
   meta: flush_handlers
 


### PR DESCRIPTION
Based on #92
Fixes #90
Fixes #84

As @geerlingguy commented on #92, do not touch the configuration file if not configuration provided
Also move configuration before starting docker, to avoid starting docker unconfigured (an possibly failing) and then restart with correct configuration